### PR TITLE
Bug 7

### DIFF
--- a/core/components/awss3mediasource/lexicon/en/default.inc.php
+++ b/core/components/awss3mediasource/lexicon/en/default.inc.php
@@ -2,3 +2,4 @@
 
 $_lang['source_type.awss3mediasource'] = 'AWS S3 Media Source 3.0';
 $_lang['source_type.awss3mediasource_desc'] = 'AWS S3 Media Source';
+$_lang['prop_s3.allowFolderCopy_desc'] = 'Allow S3 folders to be renamed and moved';

--- a/core/components/awss3mediasource/lexicon/en/default.inc.php
+++ b/core/components/awss3mediasource/lexicon/en/default.inc.php
@@ -2,3 +2,4 @@
 
 $_lang['source_type.awss3mediasource'] = 'AWS S3 Media Source 3.0';
 $_lang['source_type.awss3mediasource_desc'] = 'AWS S3 Media Source';
+$_lang['prop_s3.baseDir_desc'] = 'S3 folder path, if set will limit Media Source to set folder path.';

--- a/core/components/awss3mediasource/model/awss3mediasource/awss3mediasource.class.php
+++ b/core/components/awss3mediasource/model/awss3mediasource/awss3mediasource.class.php
@@ -689,7 +689,7 @@ class AwsS3MediaSource extends modMediaSource implements modMediaSourceInterface
             if ($child_key == $key) continue;
 
             $new_child_key = substr_replace($child_key, $new_key, 0, strlen($key));
-            $batch_commands = $this->copyFolder($child_key, $new_child_key, $batch, $batch_commands);
+            $batch_commands = $this->copyDirectory($child_key, $new_child_key, $batch, $batch_commands);
         }
         // copy files:
         foreach ($listFiles as $idx => $child_key) {

--- a/core/components/awss3mediasource/model/awss3mediasource/awss3mediasource.class.php
+++ b/core/components/awss3mediasource/model/awss3mediasource/awss3mediasource.class.php
@@ -559,7 +559,10 @@ class AwsS3MediaSource extends modMediaSource implements modMediaSourceInterface
      */
     public function removeContainer($path)
     {
-        $path = trim($path, '/');
+        /**
+         * Need the trailing delimiter
+         */
+        $path = trim($this->cleanKey($path), '/').'/';
 
         try {
             if (!$this->driver->doesObjectExist($this->bucket, $path)) {
@@ -1039,6 +1042,22 @@ class AwsS3MediaSource extends modMediaSource implements modMediaSourceInterface
     }
 
     /**
+     * @param string $path
+     *
+     * @return string $path
+     */
+    protected function cleanKey($path)
+    {
+        /**
+         * Files need only the Key which appears to be the relative path.
+         * So the URL property that MODX adds to the passed parameter needs to be removed.
+         *
+         * http://docs.aws.amazon.com/AmazonS3/latest/dev/UsingMetadata.html#object-keys
+         */
+        $path = str_replace($this->getOption('url', $this->properties, ''), '', $path);
+        return $path;
+    }
+    /**
      * Delete a file
      *
      * @param string $path
@@ -1047,6 +1066,7 @@ class AwsS3MediaSource extends modMediaSource implements modMediaSourceInterface
      */
     public function removeObject($path)
     {
+        $path = $this->cleanKey($path);
         try {
             $exists = $this->driver->doesObjectExist($this->bucket, $path);
             if (!$exists) {

--- a/core/components/awss3mediasource/model/awss3mediasource/awss3mediasource.class.php
+++ b/core/components/awss3mediasource/model/awss3mediasource/awss3mediasource.class.php
@@ -513,6 +513,12 @@ class AwsS3MediaSource extends modMediaSource implements modMediaSourceInterface
      */
     public function createContainer($name, $parentContainer)
     {
+        /** Need to check for the root/parent of Media Source to add the proper baseDir if set. */
+        if ( empty(trim($parentContainer, '/'))) {
+            $base_dir = $this->xpdo->getOption('baseDir', $this->properties, '');
+            $parentContainer = trim($base_dir, '/') . '/' ;
+        }
+
         $newPath = ltrim($parentContainer . rtrim($name, '/') . '/', '/');
 
         try {
@@ -522,7 +528,6 @@ class AwsS3MediaSource extends modMediaSource implements modMediaSourceInterface
                 return false;
             }
 
-        
             $this->driver->putObject([
                 'Bucket' => $this->bucket,
                 'Key' => $newPath,

--- a/core/components/awss3mediasource/model/awss3mediasource/awss3mediasource.class.php
+++ b/core/components/awss3mediasource/model/awss3mediasource/awss3mediasource.class.php
@@ -582,9 +582,6 @@ class AwsS3MediaSource extends modMediaSource implements modMediaSourceInterface
                 $this->addError('file', $this->xpdo->lexicon('file_folder_err_ns') . ': ' . $oldPath);
                 return false;
             }
-            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, PHP_EOL.'        [AWS S3 MS] RENAME: '.$source_key.' New: ' . $new_key.'');
-            //return false;
-            // Instantiate the client. $s3 = Aws\S3\S3Client::factory();
             $use_batch = false;
             // Copy the main object, single:
             if ( $use_batch ) {
@@ -1124,8 +1121,6 @@ class AwsS3MediaSource extends modMediaSource implements modMediaSourceInterface
      */
     public function moveObject($from, $to, $point = 'append')
     {
-        $e = new Exception();
-        $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, '[AWS S3 MS] moveObject() from: '.$from.' to: '.$to . $e->getTraceAsString());
         // Does the file/folder to be moved exist?
         $existsFrom = $this->driver->doesObjectExist($this->bucket, $from);
         if (!$existsFrom) {

--- a/core/components/awss3mediasource/model/awss3mediasource/awss3mediasource.class.php
+++ b/core/components/awss3mediasource/model/awss3mediasource/awss3mediasource.class.php
@@ -92,6 +92,11 @@ class AwsS3MediaSource extends modMediaSource implements modMediaSourceInterface
      */
     public function getContainerList($path)
     {
+        /** Need to check for the root or first loaded Media Source to add the proper baseDir if set. */
+        if ( empty(trim($path, '/'))) {
+            $base_dir = $this->xpdo->getOption('baseDir', $this->properties, '');
+            $path = trim($base_dir, '/') . '/' . ltrim($path, '/');
+        }
         list($listFiles, $listDirectories) = $this->listDirectory($path);
         $editAction = $this->getEditActionId();
 
@@ -1139,6 +1144,14 @@ class AwsS3MediaSource extends modMediaSource implements modMediaSourceInterface
                 'options' => '',
                 'value' => '',
                 'lexicon' => 'core:source',
+            ),
+            'baseDir' => array(
+                'name' => 'baseDir',
+                'desc' => 'prop_s3.baseDir_desc',
+                'type' => 'textfield',
+                'options' => '',
+                'value' => '',
+                'lexicon' => 'awss3mediasource:source',
             ),
             'key' => array(
                 'name' => 'key',

--- a/core/components/awss3mediasource/model/awss3mediasource/awss3mediasource.class.php
+++ b/core/components/awss3mediasource/model/awss3mediasource/awss3mediasource.class.php
@@ -376,6 +376,11 @@ class AwsS3MediaSource extends modMediaSource implements modMediaSourceInterface
     public function getObjectsInContainer($path)
     {
         $properties = $this->getPropertyList();
+        /** Need to check for the root/parent of Media Source to add the proper baseDir if set. */
+        if ( empty(trim($path, '/'))) {
+            $base_dir = $this->xpdo->getOption('baseDir', $this->properties, '');
+            $path = trim($base_dir, '/') . '/' ;
+        }
         list($listFiles) = $this->listDirectory($path);
         $editAction = $this->getEditActionId();
 

--- a/core/components/awss3mediasource/model/awss3mediasource/awss3mediasource.class.php
+++ b/core/components/awss3mediasource/model/awss3mediasource/awss3mediasource.class.php
@@ -1191,7 +1191,7 @@ class AwsS3MediaSource extends modMediaSource implements modMediaSourceInterface
         try {
             // This is a folder:
             if (substr(strrev($from), 0, 1) == '/') {
-                if ($this->getOption('allowFolderCopy', $this->properties, false)) {
+                if (!$this->getOption('allowFolderCopy', $this->properties, false)) {
                     $this->xpdo->error->message = $this->xpdo->lexicon('s3_no_move_folder', array(
                         'from' => $from
                     ));

--- a/core/components/awss3mediasource/model/awss3mediasource/awss3mediasource.class.php
+++ b/core/components/awss3mediasource/model/awss3mediasource/awss3mediasource.class.php
@@ -121,6 +121,7 @@ class AwsS3MediaSource extends modMediaSource implements modMediaSourceInterface
                 'type' => 'dir',
                 'leaf' => false,
                 'path' => $currentPath,
+                'pathRelative' => $currentPath,
                 'perms' => '',
             );
 

--- a/core/components/awss3mediasource/model/awss3mediasource/awss3mediasource.class.php
+++ b/core/components/awss3mediasource/model/awss3mediasource/awss3mediasource.class.php
@@ -885,7 +885,17 @@ class AwsS3MediaSource extends modMediaSource implements modMediaSourceInterface
      */
     public function createObject($path, $name, $content)
     {
+        /** Need to check for the root/parent of Media Source to add the proper baseDir if set. */
+        if ( empty(trim($path, '/'))) {
+            $base_dir = $this->xpdo->getOption('baseDir', $this->properties, '');
+            $path = trim($base_dir, '/') . '/' ;
+        }
+
+        $key = ltrim($path . trim($name, '/'), '/');
+        $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Key ' . $key);
+
         $key = $path . $name;
+        $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, 'Key ' . $key);
 
         try {
             $exists = $this->driver->doesObjectExist($this->bucket, $key);
@@ -1087,19 +1097,32 @@ class AwsS3MediaSource extends modMediaSource implements modMediaSourceInterface
      * Get the contents of a specified file
      *
      * @param string $objectPath
+     * @param boolean $resend_on_error if true will call on itself and attach the baseDir on 404
      *
      * @return array
      */
-    public function getObjectContents($objectPath)
+    public function getObjectContents($objectPath, $resend_on_error=true)
     {
         $imageExtensions = $this->getOption('imageExtensions', $this->properties, 'jpg,jpeg,png,gif');
         $imageExtensions = explode(',', $imageExtensions);
         $fileExtension = pathinfo($objectPath, PATHINFO_EXTENSION);
 
-        $object = $this->driver->getObject([
-            'Bucket' => $this->bucket,
-            'Key' => $objectPath
-        ]);
+        try {
+            $object = $this->driver->getObject([
+                'Bucket' => $this->bucket,
+                'Key' => $objectPath
+            ]);
+        } catch (Exception $e) {
+            /** Need to check for the root/parent of Media Source to add the proper baseDir if set for the root Create File. */
+            $base_dir = $this->xpdo->getOption('baseDir', $this->properties, '');
+            if (!empty(trim($base_dir, '/')) && $resend_on_error) {
+                $path = trim($base_dir, '/') . '/' .$objectPath ;
+                return $this->getObjectContents($path, false);
+            } else {
+                $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, '[AWS S3 MS] Error occurred when retrieving object: ' . $objectPath . ' msg: ' . $e->getMessage());
+                return false;
+            }
+        }
 
         $lastModified = $object->get('LastModified');
         $timeFormat = $this->ctx->getOption('manager_time_format');


### PR DESCRIPTION
This includes #3 fix as the $path/$key issue is needed for this fix. I also included some code that does batch. I hard coded the $use_batch=false since I was getting fatal errors. This seems to be the preferred method from the SDK docs so maybe someone else can get it to work. By default it then copies files one by one so may be memory/time intensive for a large folder. S3 does not have a rename or move method that is why have to copy and delete. 

This also add a boolean allowFolderCopy property to the Media Source so the Folder Rename/Move can be turned on/off per media source.